### PR TITLE
Error: "Unexpected token 'S', 'Starting s'... is not valid JSON" when running Claude Desktop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "text-toolkit",
+  "name": "@cicatriz/text-toolkit",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "text-toolkit",
+      "name": "@cicatriz/text-toolkit",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ registerResources(server);
 async function startServer() {
   try {
     if (sseMode) {
-      console.log(`Starting server in SSE mode on port ${port}...`);
+      console.error(`Starting server in SSE mode on port ${port}...`);
 
       // Create Express app
       const app = express();
@@ -103,10 +103,10 @@ async function startServer() {
           // Clean up on close
           res.on("close", () => {
             delete transports[sessionId];
-            console.log(`Session ${sessionId} closed`);
+            console.error(`Session ${sessionId} closed`);
           });
 
-          console.log(`New SSE session established: ${sessionId}`);
+          console.error(`New SSE session established: ${sessionId}`);
 
           // Connect the transport to the server
           await server.connect(transport);
@@ -140,10 +140,10 @@ async function startServer() {
       // Start the Express server
       const server_port = parseInt(port, 10);
       app.listen(server_port, () => {
-        console.log(`Express server listening on port ${server_port}`);
+        console.error(`Express server listening on port ${server_port}`);
       });
     } else {
-      console.log('Starting server in stdio mode...');
+      console.error('Starting server in stdio mode...');
       const transport = new StdioServerTransport();
       await server.connect(transport);
     }


### PR DESCRIPTION
Fixes #1

All non-JSON console.log statements in index.ts have been redirected to stderr using console.error. This will prevent plain text output from interfering with JSON-RPC communication, resolving the MCP text-toolkit JSON parsing error in Claude Desktop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated server and session lifecycle messages to display as errors instead of logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->